### PR TITLE
Update README with config file usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,16 @@ database = "Globetrot"
 filePath = "../playground"
 env = "production"
 ```
+
+Once you have created a configuration file in any of the above formats,
+you can run a migration by simply pointing globetrot at the directory
+containing that file. The tool will look for a file named `globetrot`
+with one of the supported extensions and use its values in place of
+individual command‑line arguments.
+
+```bash
+./globetrot migrate --configPath "./path/to/config"
+```
+
+Alternatively, you may set the `GLOBETROT_CONFIGPATH` environment
+variable to avoid passing `--configPath` every time.


### PR DESCRIPTION
## Summary
- document using `--configPath` for migrations

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686152e400a88330aa735b345ec7d660